### PR TITLE
Add more heading levels to avoid opaque errors

### DIFF
--- a/md_to_bgg.py
+++ b/md_to_bgg.py
@@ -164,7 +164,7 @@ class BGGRenderer:
 
         # There is no concept of header in BGG markup, so we simulate this by
         # using the default Large and Huge font sizes:
-        size = {1: 24, 2: 18}[element.level]  # Maximum 2 levels!
+        size = {1: 24, 2: 18, 3: 14, 4: 12, 5: 11, 6: 10}[element.level]  # All 6 levels!
 
         result = "".join([
             self._prefix,


### PR DESCRIPTION
It seems harmless to support all header levels.  I had a third-level header in my markdown and the error I got was completely opaque:

```
Traceback (most recent call last):
  File "md_to_bgg.py", line 283, in <module>
    print(parse_and_render(input_file.read()))
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/__init__.py", line 112, in __call__
    return self.convert(text)
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/__init__.py", line 109, in convert
    return self.render(self.parse(text))
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/__init__.py", line 129, in render
    return r.render(parsed)
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/renderer.py", line 69, in render
    return self.render_children(element)
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/renderer.py", line 83, in render_children
    rendered = [self.render(child) for child in element.children]  # type: ignore
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/renderer.py", line 83, in <listcomp>
    rendered = [self.render(child) for child in element.children]  # type: ignore
  File "/Users/mcd/.pyenv/versions/3.6.15/lib/python3.6/site-packages/marko/renderer.py", line 68, in render
    return render_func(element)
  File "md_to_bgg.py", line 167, in render_heading
    size = {1: 24, 2: 18}[element.level]  # Maximum 2 levels!
KeyError: 3
```